### PR TITLE
feat: allow /busID so users can only see a given bus route

### DIFF
--- a/api/src/api.controller.ts
+++ b/api/src/api.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
 import { ApiService } from './api.service';
 
 @Controller()
@@ -8,5 +8,10 @@ export class ApiController {
   @Get('/bus-times')
   getBusTimes() {
     return this.apiService.getBusTimes();
+  }
+
+  @Get('/bus-times/:busId')
+  getOneBusTimes(@Param('busId', ParseIntPipe) busId: number) {
+    return this.apiService.getOneBusTimes(busId);
   }
 }

--- a/api/src/api.service.ts
+++ b/api/src/api.service.ts
@@ -27,6 +27,28 @@ export class ApiService {
 
     return todayBusTimes;
   }
+  getOneBusTimes(busId: number) {
+    const randomBusTimes = this.generateRandomBusTimes(5);
+    const orderedBusTimes = _.sortBy(randomBusTimes, ['minutesUntilArrival']);
+
+    // Note: this isn't necessarily the best place for this logic.
+    // Todo: could make a separate private method?
+    const currentDayOfWeek = new Date().getDay();
+
+    // For each bus, check each value in the nonOperationalDays array
+    // If any one of those values matches the currentDayOfWeek, omit that bus
+    const todayBusTimes = _.filter(orderedBusTimes, (bus: BusTime) => {
+      return !bus.nonOperationalDays.includes(currentDayOfWeek);
+    });
+
+    console.log('joe says', busId);
+
+    const thisRouteOnly = _.filter(todayBusTimes, (bus: BusTime) => {
+      return bus.busId == busId;
+    });
+
+    return thisRouteOnly;
+  }
   private generateRandomBusTimes(timesToGenerate: number) {
     let data: BusTime[] = [];
     for (let i = 0; i < timesToGenerate; i++) {

--- a/api/src/api.service.ts
+++ b/api/src/api.service.ts
@@ -12,6 +12,19 @@ export interface BusTime {
 @Injectable()
 export class ApiService {
   getBusTimes() {
+    return this.filterAndSortBusTimes();
+  }
+  getOneBusTimes(busId: number) {
+    const thisRouteOnly = _.filter(
+      this.filterAndSortBusTimes(),
+      (bus: BusTime) => {
+        return bus.busId == busId;
+      },
+    );
+
+    return thisRouteOnly;
+  }
+  private filterAndSortBusTimes() {
     const randomBusTimes = this.generateRandomBusTimes(5);
     const orderedBusTimes = _.sortBy(randomBusTimes, ['minutesUntilArrival']);
 
@@ -26,28 +39,6 @@ export class ApiService {
     });
 
     return todayBusTimes;
-  }
-  getOneBusTimes(busId: number) {
-    const randomBusTimes = this.generateRandomBusTimes(5);
-    const orderedBusTimes = _.sortBy(randomBusTimes, ['minutesUntilArrival']);
-
-    // Note: this isn't necessarily the best place for this logic.
-    // Todo: could make a separate private method?
-    const currentDayOfWeek = new Date().getDay();
-
-    // For each bus, check each value in the nonOperationalDays array
-    // If any one of those values matches the currentDayOfWeek, omit that bus
-    const todayBusTimes = _.filter(orderedBusTimes, (bus: BusTime) => {
-      return !bus.nonOperationalDays.includes(currentDayOfWeek);
-    });
-
-    console.log('joe says', busId);
-
-    const thisRouteOnly = _.filter(todayBusTimes, (bus: BusTime) => {
-      return bus.busId == busId;
-    });
-
-    return thisRouteOnly;
   }
   private generateRandomBusTimes(timesToGenerate: number) {
     let data: BusTime[] = [];

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -49,6 +49,7 @@ const App: React.FC<Props> = () => {
         <h1>
           Live bus times for <b>Park Road</b>
         </h1>
+        {!busData && <div>Loading...</div>}
         {busData && (
           <div className="CardContainer">
             {busData.map((busTime) => (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,7 +16,13 @@ const App: React.FC<Props> = () => {
   const [busData, setBusData] = useState<Array<BusData> | null>(null);
 
   useEffect(() => {
-    const endpoint_url = "http://localhost:3000/bus-times";
+    const optionalBusId: string = window.location.pathname;
+
+    let endpoint_url: string = "http://localhost:3000/bus-times";
+
+    if (optionalBusId !== "") {
+      endpoint_url += optionalBusId;
+    }
 
     // Todo: basic error-handling for empty response etc.
     const fetchData = () => {


### PR DESCRIPTION
E.g. visit `/176` (on a day when it's running :¬) and note that only route 176 arrival times are shown:

![2024-03-22 16_24_29-Web](https://github.com/joe-dev-public/ridetandem-developer-assessment/assets/94115299/8dc39ea9-c4a5-4e42-aef9-93c5938cd323)

Conversely note that on a Friday, route `/185` shows no results:

![2024-03-22 16_24_40-Web](https://github.com/joe-dev-public/ridetandem-developer-assessment/assets/94115299/fc281cdb-3437-44ec-9676-7bd1699859ac)
