### PR TITLE
"Extra time" feature: filter routes UI

### DIFF
--- a/api/src/api.controller.ts
+++ b/api/src/api.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import { Controller, Get } from '@nestjs/common';
 import { ApiService } from './api.service';
 
 @Controller()
@@ -10,8 +10,21 @@ export class ApiController {
     return this.apiService.getBusTimes();
   }
 
-  @Get('/bus-times/:busId')
-  getOneBusTimes(@Param('busId', ParseIntPipe) busId: number) {
-    return this.apiService.getOneBusTimes(busId);
-  }
+  // Note: the changes below would allow us to filter by a query string like:
+  // "/bus-times?route=a,b,c". However, for the "filter visible routes" FE
+  // feature, we actually don't want to filter like this in the BE! (Because,
+  // given how everything is currently set up, that would mean the FE wouldn't
+  // know which routes actually had data to display.)
+  //
+  // @Get('/bus-times')
+  // getBusTimes(@Query('route', new DefaultValuePipe('all')) route: string) {
+  //   if (route === 'all') {
+  //     return this.apiService.getBusTimes([route]);
+  //   }
+
+  //   // Todo: could we use a pipe to validate this query string? (Where?)
+  //   const routes: Array<string> = route.split(',');
+
+  //   return this.apiService.getBusTimes(routes);
+  // }
 }

--- a/api/src/api.service.ts
+++ b/api/src/api.service.ts
@@ -14,16 +14,28 @@ export class ApiService {
   getBusTimes() {
     return this.filterAndSortBusTimes();
   }
-  getOneBusTimes(busId: number) {
-    const thisRouteOnly = _.filter(
-      this.filterAndSortBusTimes(),
-      (bus: BusTime) => {
-        return bus.busId == busId;
-      },
-    );
 
-    return thisRouteOnly;
-  }
+  // Note: see comment in controller. The below would allow us to have a
+  // "/bus-times?route=a,b,c" query string, but we don't actually want that
+  // for now.
+  //
+  // getBusTimes(routes?: Array<string>) {
+  //   if (routes[0] === 'all') {
+  //     return this.filterAndSortBusTimes();
+  //   }
+
+  //   const thesesRoutesOnly = _.filter(
+  //     this.filterAndSortBusTimes(),
+  //     (bus: BusTime) => {
+  //       // Todo: hopefully not necessary to coerce to string here if we can
+  //       // correctly use a pipe to validate/transform in controller?
+  //       return routes.includes(String(bus.busId));
+  //     },
+  //   );
+
+  //   return thesesRoutesOnly;
+  // }
+
   private filterAndSortBusTimes() {
     const randomBusTimes = this.generateRandomBusTimes(5);
     const orderedBusTimes = _.sortBy(randomBusTimes, ['minutesUntilArrival']);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
+import RouteButton from "./RouteButton";
 
 interface Props {}
 
@@ -12,17 +13,25 @@ interface BusData {
   minutesUntilArrival: number;
 }
 
+// JS object key names are always converted to strings?
+interface UniqueBusRoutes {
+  [busId: string]: boolean;
+}
+
 const App: React.FC<Props> = () => {
   const [busData, setBusData] = useState<Array<BusData> | null>(null);
+  const [uniqueBusRoutes, setUniqueBusroutes] =
+    useState<UniqueBusRoutes | null>(null);
+  const [filterRoutes, setFilterRoutes] = useState<boolean>(false);
 
   useEffect(() => {
-    const optionalBusId: string = window.location.pathname;
+    const endpoint_url: string = "http://localhost:3000/bus-times";
 
-    let endpoint_url: string = "http://localhost:3000/bus-times";
-
-    if (optionalBusId !== "") {
-      endpoint_url += optionalBusId;
-    }
+    // Todo: update URL with query string - just to allow users to bookmark
+    // their filter (it doesn't affect API request or reponse).
+    // const url = new URL(location);
+    // url.searchParams.set("route", urlQuery);
+    // history.pushState({}, "", url);
 
     // Todo: basic error-handling for empty response etc.
     const fetchData = () => {
@@ -42,6 +51,57 @@ const App: React.FC<Props> = () => {
     };
   }, []);
 
+  useEffect(() => {
+    // Get a list of unique, sorted bus routes for the current data response:
+    const uniqueRoutesArray: Array<number> = [];
+    busData?.forEach((busTime) => {
+      if (!uniqueRoutesArray.includes(busTime.busId)) {
+        uniqueRoutesArray.push(busTime.busId);
+      }
+    });
+    uniqueRoutesArray.sort();
+
+    const uniqueRoutesObj: UniqueBusRoutes = {};
+
+    const currentUniqueRoutes = { ...uniqueBusRoutes };
+
+    // Create the object of bus routes, each route is not selected by default:
+    uniqueRoutesArray.forEach((route) => {
+      // Check to see if the route is already selected in state, and maintain that if so:
+      if (currentUniqueRoutes[String(route)] === true) {
+        uniqueRoutesObj[String(route)] = true;
+      } else {
+        uniqueRoutesObj[String(route)] = false;
+      }
+    });
+
+    setUniqueBusroutes(uniqueRoutesObj);
+  }, [busData]);
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    // Copy existing unique routes object
+    const currentUniqueRoutes = { ...uniqueBusRoutes };
+
+    // Toggle selected route's bool
+    const clickedBusRoute: string = event.target?.value;
+    currentUniqueRoutes[clickedBusRoute] =
+      !currentUniqueRoutes[clickedBusRoute];
+
+    // If any routes are filtered, make sure the global flag knows this:
+    let flag: boolean = false;
+    Object.keys(currentUniqueRoutes).forEach((route) => {
+      if (currentUniqueRoutes[route] === true) {
+        flag = true;
+      }
+    });
+    setFilterRoutes(flag);
+
+    // Set the array in state again
+    setUniqueBusroutes(currentUniqueRoutes);
+
+    event.preventDefault();
+  };
+
   return (
     <div className="App">
       <div>
@@ -51,26 +111,49 @@ const App: React.FC<Props> = () => {
         </h1>
         {!busData && <div>Loading...</div>}
         {busData && (
-          <div className="CardContainer">
-            {busData.map((busTime) => (
-              <div className="Card" key={busTime.id}>
-                <div className="Card__Header">
-                  <b>{busTime.busId}</b>
-                </div>
-                <div className="Card__Details">
-                  <div className="Card__Destination">
-                    To {busTime.destination}
-                  </div>
-                  <div>
-                    {busTime.minutesUntilArrival <= 1
-                      ? // Todo: could use <span> with class to highlight "Due"
-                        "Due"
-                      : `${busTime.minutesUntilArrival} mins`}
-                  </div>
-                </div>
+          <>
+            {uniqueBusRoutes && (
+              <div className="ButtonContainer">
+                {Object.keys(uniqueBusRoutes).map((route) => (
+                  <RouteButton
+                    route={route}
+                    key={route}
+                    selected={uniqueBusRoutes[route]}
+                    onClick={handleClick}
+                  />
+                ))}
               </div>
-            ))}
-          </div>
+            )}
+            <div className="CardContainer">
+              {busData.map((busTime) => {
+                if (
+                  filterRoutes === false ||
+                  uniqueBusRoutes[busTime.busId] === true
+                ) {
+                  return (
+                    <div className="Card" key={busTime.id}>
+                      <div className="Card__Header">
+                        <b>{busTime.busId}</b>
+                      </div>
+                      <div className="Card__Details">
+                        <div className="Card__Destination">
+                          To {busTime.destination}
+                        </div>
+                        <div>
+                          {busTime.minutesUntilArrival <= 1
+                            ? // Todo: could use <span> with class to highlight "Due"
+                              "Due"
+                            : `${busTime.minutesUntilArrival} mins`}
+                        </div>
+                      </div>
+                    </div>
+                  );
+                } else {
+                  return null;
+                }
+              })}
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/web/src/RouteButton.tsx
+++ b/web/src/RouteButton.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+interface Props {
+  route: string;
+  selected: boolean;
+  onClick: Function;
+}
+
+const RouteButton: React.FC<Props> = ({ route, selected, onClick }) => {
+  return (
+    <input
+      className={selected ? "Button Selected" : "Button"}
+      type="button"
+      value={route}
+      onClick={onClick}
+    />
+  );
+};
+
+export default RouteButton;

--- a/web/src/style/index.css
+++ b/web/src/style/index.css
@@ -20,6 +20,30 @@ body {
   margin: 0 16px;
 }
 
+.ButtonContainer {
+  display: flex;
+  margin-bottom: 24px;
+}
+
+.ButtonContainer > * + * {
+  margin-left: 8px;
+}
+
+.Button {
+  background: #555;
+  border: 1px solid #d7d7d7;
+  border-radius: 2px;
+  color: #fff;
+  cursor: pointer;
+  font-weight: bold;
+  padding: 8px 16px;
+  user-select: none;
+}
+
+.Selected {
+  background: #dc241f;
+}
+
 /* Todo: is use of double underscore (__) a BEM/other naming convention?
 I might be able to improve the class name here. */
 /* Adjacent sibling combinator ;¬) */


### PR DESCRIPTION
After completing the main requirements and one stretch goal in the time given, I was still interested in working on one improvement idea.

This branch adds some basic route-filtering buttons in the FE.

(It also reverts the `/busId` feature that's present on main, as I was exploring a `/?route=a,b,c` feature in the BE -- which worked, but I realised wasn't compatible with my quick & messy FE changes! 😌)

I've left this additional work unmerged in this PR to keep a clear separation between what I completed in "regular time" and "extra time" :¬)

(All the same, feel free to pull this branch and test the feature locally.)

Example screenshots:

| No filter | Show only route 176 | Show routes 185 & 193 |
|-|-|-|
| ![2024-03-25 10_13_38-Web](https://github.com/joe-dev-public/ridetandem-developer-assessment/assets/94115299/0ca9f6eb-3e6c-4915-90e4-4cbb2b5040a3) | ![2024-03-25 10_13_43-Web](https://github.com/joe-dev-public/ridetandem-developer-assessment/assets/94115299/50beea4c-50a8-4603-99e4-5d4126ae8763) | ![2024-03-25 10_13_46-Web](https://github.com/joe-dev-public/ridetandem-developer-assessment/assets/94115299/e553ce97-16fe-4c67-871f-a7452e0d7e6e) |
